### PR TITLE
add deploy-to-cloudflare action

### DIFF
--- a/deploy-to-cloudflare/README.md
+++ b/deploy-to-cloudflare/README.md
@@ -1,0 +1,66 @@
+# deploy-to-cloudflare
+
+Builds and deploys a Next.js application to Cloudflare.
+
+## Inputs
+
+- `application_path`
+  - **required**
+  - The path of the application you want to deploy within its repository.
+- `branch`:
+  - **optional**
+  - The branch name to pass along to Cloudflare.
+  - This value is needed to publish to production upon tagging as Cloudflare uses the branch name to
+    figure out whether it should deploy to preview or production.
+  - Additionally, in preview environments, Cloudflare will deploy the codebase to a subdomain based on the branch name.
+    If you push to a branch called `example`, Cloudflare will deploy to `https://example.<project name in CF>.pages.dev`.
+    Using this input you can override this default behavior and have Cloudflare deploy to a different subdomain.
+- `cloudflare_project_name`
+  - **required**
+  - The name of the project in Cloudflare.
+
+### Secrets
+
+Actions, contrary to workflows, can't access secrets directly.
+As a result, the following secrets need to be passed as inputs:
+
+- `cloudflare_account_id`
+  - **required**
+  - The Cloudflare account ID the given project belongs to.
+- `cloudflare_api_token`
+  - **required**
+  - A Cloudflare API token.
+- `github_token`
+  - **required**
+  - GitHub token with the `packages:read` permission.
+
+## Outputs
+
+N/A
+
+## Environment variables
+
+The variables passed using the `env` property will be made available to the action as a whole.
+These are especially useful for the application build step, see example below.
+
+## Example
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tailor-inc/github-actions/deploy-to-cloudflare@main
+        with:
+          application_path: apps/dashboard
+          cloudflare_project_name: console
+          cloudflare_account_id: ${{secrets.CLOUDFLARE_ACCOUNT_ID}}
+          cloudflare_api_token: ${{secrets.CLOUDFLARE_API_TOKEN}}
+          github_token: ${{secrets.GITHUB_TOKEN}}
+        env:
+          NEXT_PUBLIC_DATADOG_RUM_SERVICE: console
+          NEXT_PUBLIC_DATADOG_RUM_APPLICATION_ID: d71b015c-dd30-4129-b50b-b679a796c23a
+          NEXT_PUBLIC_DATADOG_RUM_CLIENT_TOKEN: pubcc21a546a3d08a69dffe75492e4dff12
+          NEXT_PUBLIC_DEPLOYED_ENV: preview
+          NEXT_PUBLIC_DOMAIN: https://tailor-pf.erp.dev/query
+```

--- a/deploy-to-cloudflare/action.yml
+++ b/deploy-to-cloudflare/action.yml
@@ -1,0 +1,80 @@
+name: Deploy to Cloudflare
+
+inputs:
+  application_path:
+    type: string
+    required: true
+    description: The path of the application you want to deploy within its repository.
+  branch:
+    type: string
+    required: false
+    description: |-
+      The branch name to pass along to Cloudflare.
+      This value is needed to publish to production upon tagging as Cloudflare uses the branch name to
+      figure out whether it should deploy to preview or production.
+      Additionally, in preview environments, Cloudflare will deploy the codebase to a subdomain based on the branch name.
+      If you push to a branch called `example`, Cloudflare will deploy to `https://example.<project name in CF>.pages.dev`.
+      Using this input you can override this default behavior and have Cloudflare deploy to a different subdomain.
+  cloudflare_project_name:
+    type: string
+    required: true
+    description: The name of the project in Cloudflare.
+  cloudflare_account_id:
+    type: string
+    required: true
+    description: The Cloudflare account ID the given project belongs to.
+  cloudflare_api_token:
+    type: string
+    required: true
+    description: A Cloudflare API token.
+  github_token:
+    type: string
+    required: true
+    description: GitHub token with the `packages:read` permission.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+        registry-url: https://npm.pkg.github.com
+
+    - name: Setup pnpm
+      shell: bash
+      run: corepack enable
+
+    - name: Install dependencies
+      shell: bash
+      working-directory: ${{ inputs.application_path }}
+      run: pnpm install
+      env:
+        GITHUB_PACKAGES_READ_TOKEN: ${{ inputs.github_token }}
+
+    - name: Install next-on-pages
+      shell: bash
+      working-directory: ${{ inputs.application_path }}
+      run: pnpm install -D @cloudflare/next-on-pages@1
+      env:
+        GITHUB_PACKAGES_READ_TOKEN: ${{ inputs.github_token }}
+
+    - name: Build application
+      shell: bash
+      working-directory: ${{ inputs.application_path }}
+      run: pnpm exec next-on-pages
+      env:
+        GITHUB_PACKAGES_READ_TOKEN: ""
+        NEXT_PUBLIC_DEPLOYED_GIT_COMMIT_SHA: ${{github.sha}}
+        NEXT_TELEMETRY_DISABLED: "1" # see https://nextjs.org/telemetry
+
+    - name: Publish to Cloudflare Pages
+      uses: cloudflare/pages-action@v1
+      with:
+        apiToken: ${{ inputs.cloudflare_api_token }}
+        accountId: ${{ inputs.cloudflare_account_id }}
+        branch: ${{ inputs.branch }}
+        projectName: ${{ inputs.cloudflare_project_name }}
+        directory: ${{ inputs.application_path }}/.vercel/output/static
+        wranglerVersion: "3"


### PR DESCRIPTION
For [FL-56](https://tailor.atlassian.net/browse/FL-56).

In a nutshell, turns https://github.com/tailor-inc/platform-frontend-services/blob/530e2093362bbb06db265f8c88187098a1f67ce9/.github/workflows/deploy_to_cloudflare.yml into a shared action, with some adjustements in behavior.



[FL-56]: https://tailor.atlassian.net/browse/FL-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ