### PR TITLE
fix: add content-type headers for CF Pages

### DIFF
--- a/deploy-to-cloudflare/action.yml
+++ b/deploy-to-cloudflare/action.yml
@@ -69,6 +69,19 @@ runs:
         NEXT_PUBLIC_DEPLOYED_GIT_COMMIT_SHA: ${{github.sha}}
         NEXT_TELEMETRY_DISABLED: "1" # see https://nextjs.org/telemetry
 
+    - name: Add headers
+      shell: bash
+      working-directory: ${{ inputs.application_path }}
+      run: |
+        cat <<EOF >> .vercel/output/static/_headers
+
+        /*.js
+          Content-Type: text/javascript
+
+        /*.css
+          Content-Type: text/css
+        EOF
+
     - name: Publish to Cloudflare Pages
       uses: cloudflare/pages-action@v1
       with:


### PR DESCRIPTION
For whatever reason, manual deployments of nextjs apps on Cloudflare Pages may end up with js and css files served without a Content-Type header. This in turn makes the browser block them because `X-Content-Type-Options: nosniff` is set ([MDN article](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options)) and with a blank MIME type, the browser deems them inappropriate.

This PR adds to the `_headers` file that's produced post build, ending up with a result like:

```
# === START AUTOGENERATED @cloudflare/next-on-pages IMMUTABLE HEADERS ===
/_next/static/*
  cache-control: public,max-age=31536000,immutable
# === END AUTOGENERATED @cloudflare/next-on-pages IMMUTABLE HEADERS ===

/*.js
  Content-Type: text/javascript

/*.css
  Content-Type: text/css
```

See also https://developers.cloudflare.com/pages/configuration/headers/