### PR TITLE
feat(deploy-to-cloudflare): update setup-node

### DIFF
--- a/deploy-to-cloudflare/README.md
+++ b/deploy-to-cloudflare/README.md
@@ -2,6 +2,17 @@
 
 Builds and deploys a Next.js application to Cloudflare.
 
+It assumes the host project has a `package.json` at its root and it defines the node version, e.g.
+
+```jsonc
+{
+  // ...
+  "engines": {
+    "node": "20.x"
+  }
+}
+```
+
 ## Inputs
 
 - `application_path`
@@ -58,9 +69,5 @@ jobs:
           cloudflare_api_token: ${{secrets.CLOUDFLARE_API_TOKEN}}
           github_token: ${{secrets.GITHUB_TOKEN}}
         env:
-          NEXT_PUBLIC_DATADOG_RUM_SERVICE: console
-          NEXT_PUBLIC_DATADOG_RUM_APPLICATION_ID: d71b015c-dd30-4129-b50b-b679a796c23a
-          NEXT_PUBLIC_DATADOG_RUM_CLIENT_TOKEN: pubcc21a546a3d08a69dffe75492e4dff12
-          NEXT_PUBLIC_DEPLOYED_ENV: preview
-          NEXT_PUBLIC_DOMAIN: https://tailor-pf.erp.dev/query
+          NEXT_PUBLIC_API_URL: https://api.tailor.tech
 ```

--- a/deploy-to-cloudflare/action.yml
+++ b/deploy-to-cloudflare/action.yml
@@ -37,14 +37,29 @@ runs:
   steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version-file: package.json
         registry-url: https://npm.pkg.github.com
 
-    - name: Setup pnpm
+    - uses: pnpm/action-setup@v3
+      with:
+        run_install: false
+
+    - name: Get pnpm store directory
       shell: bash
-      run: corepack enable
+      run: |
+        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+      env:
+        GITHUB_PACKAGES_READ_TOKEN: ${{ inputs.github_token }}
+
+    - uses: actions/cache@v4
+      name: Setup pnpm cache
+      with:
+        path: ${{ env.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
 
     - name: Install dependencies
       shell: bash

--- a/deploy-to-cloudflare/action.yml
+++ b/deploy-to-cloudflare/action.yml
@@ -37,29 +37,17 @@ runs:
   steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/setup-node@v4
-      with:
-        node-version-file: package.json
-        registry-url: https://npm.pkg.github.com
-
     - uses: pnpm/action-setup@v3
       with:
-        run_install: false
+        run_install: |
+          - args: [--global, '@cloudflare/next-on-pages@1']
 
-    - name: Get pnpm store directory
-      shell: bash
-      run: |
-        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-      env:
-        GITHUB_PACKAGES_READ_TOKEN: ${{ inputs.github_token }}
-
-    - uses: actions/cache@v4
-      name: Setup pnpm cache
+    - uses: actions/setup-node@v4
       with:
-        path: ${{ env.STORE_PATH }}
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-store-
+        cache: pnpm
+        cache-dependency-path: pnpm-lock.yaml
+        node-version-file: package.json
+        registry-url: https://npm.pkg.github.com
 
     - name: Install dependencies
       shell: bash
@@ -68,17 +56,10 @@ runs:
       env:
         GITHUB_PACKAGES_READ_TOKEN: ${{ inputs.github_token }}
 
-    - name: Install next-on-pages
-      shell: bash
-      working-directory: ${{ inputs.application_path }}
-      run: pnpm install -D @cloudflare/next-on-pages@1
-      env:
-        GITHUB_PACKAGES_READ_TOKEN: ${{ inputs.github_token }}
-
     - name: Build application
       shell: bash
       working-directory: ${{ inputs.application_path }}
-      run: pnpm exec next-on-pages
+      run: next-on-pages
       env:
         GITHUB_PACKAGES_READ_TOKEN: ""
         NEXT_PUBLIC_DEPLOYED_GIT_COMMIT_SHA: ${{github.sha}}


### PR DESCRIPTION
Also,
- get the node version from the package.json file that's assumed to be present at root and defines the node version.
- cache installed packages using setup-node's cache option
- simplify pnpm integration using pnpm/action-setup